### PR TITLE
chore(ci): run integ tests again deb installation in ci

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -28,4 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: fake-step
-        run: echo "Hello World!"
+        # run: echo "Hello World!"
+        run: |
+          exit 1 

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -22,6 +22,7 @@ on:
       - master
       - 'v1.*'
     types: [ opened, reopened, synchronize ]
+
 jobs:
   build-all-fake:
     runs-on: ubuntu-latest

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -18,6 +18,7 @@ on:
       - build-all
     branches:
       - master
+      - 'v1.*'
     types:
       - completed
 

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -28,3 +28,4 @@ jobs:
     steps:
       - name: fake-step
         run: echo "Hello Hello!"
+

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -9,19 +9,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: LTE integ test magma-deb
+name: test
 
 on:
   workflow_dispatch: null
   workflow_run:
-    workflows: [build-all]
-    types:
+    workflows: 
+      - build-all
+    types: 
       - completed
 
 jobs:
-  fake-job:
+  on-success:
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: macos-12
     steps:
-      - name: fake-step
-        run: echo "Hello Hello!"
+      - run: echo 'The triggering workflow passed'
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow failed'

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -14,7 +14,10 @@ name: LTE integ test magma-deb
 on:
   workflow_dispatch: null
   workflow_run:
-    workflows: [build-all]
+    workflows:
+      - build-all
+    branches:
+      - master
     types:
       - completed
 

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -28,4 +28,3 @@ jobs:
     steps:
       - name: fake-step
         run: echo "Hello Hello!"
-

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -14,11 +14,7 @@ name: LTE integ test magma-deb
 on:
   workflow_dispatch: null
   workflow_run:
-    workflows:
-      - build-all
-    branches:
-      - master
-      - 'v1.*'
+    workflows: [build-all]
     types:
       - completed
 

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -544,11 +544,6 @@ def integ_test_deb_installation(
     execute(_make_integ_tests)
     execute(_run_integ_tests, gateway_ip)
 
-    if not gateway_host:
-        setup_env_vagrant()
-    else:
-        env.hosts = [gateway_host]
-
 
 def run_integ_tests(tests=None, federated_mode=False):
     """

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -49,6 +49,7 @@ in `release/magma.lockfile`
     fab dev package upload_to_aws
 """
 
+IP_ADDRESS = "192.168.60.142"
 AGW_ROOT = "$MAGMA_ROOT/lte/gateway"
 AGW_PYTHON_ROOT = "$MAGMA_ROOT/lte/gateway/python"
 FEG_INTEG_TEST_ROOT = AGW_PYTHON_ROOT + "/integ_tests/federated_tests"
@@ -414,6 +415,24 @@ def bazel_integ_test_post_build(
         env.hosts = [gateway_host]
 
 
+def _setup_vm(host, name, ansible_role, ansible_file, destroy_vm, provision_vm):
+    ip = None
+    if not host:
+        host = vagrant_setup(
+            name, destroy_vm, force_provision=provision_vm,
+        )
+    else:
+        ansible_setup(host, ansible_role, ansible_file)
+        ip = host.split('@')[1].split(':')[0]
+    return host, ip
+
+def _setup_gateway(gateway_host, name, ansible_role, ansible_file, destroy_vm, provision_vm):
+    gateway_host, gateway_ip = _setup_vm(gateway_host, name, ansible_role, ansible_file, destroy_vm, provision_vm)
+    if gateway_ip == None:
+        gateway_ip = IP_ADDRESS
+    return gateway_host, gateway_ip
+
+
 def integ_test(
     gateway_host=None, test_host=None, trf_host=None,
     destroy_vm='True', provision_vm='True',
@@ -441,16 +460,7 @@ def integ_test(
 
     # Setup the gateway: use the provided gateway if given, else default to the
     # vagrant machine
-    gateway_ip = '192.168.60.142'
-
-    if not gateway_host:
-        gateway_host = vagrant_setup(
-            'magma', destroy_vm, force_provision=provision_vm,
-        )
-    else:
-        ansible_setup(gateway_host, "dev", "magma_dev.yml")
-        gateway_ip = gateway_host.split('@')[1].split(':')[0]
-
+    gateway_host, gateway_ip = _setup_gateway(gateway_host, "magma", "dev", "magma_dev.yml", destroy_vm, provision_vm)
     execute(_dist_upgrade)
     execute(_build_magma)
     execute(_run_sudo_python_unit_tests)
@@ -458,23 +468,13 @@ def integ_test(
 
     # Setup the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
-    if not trf_host:
-        trf_host = vagrant_setup(
-            'magma_trfserver', destroy_vm, force_provision=provision_vm,
-        )
-    else:
-        ansible_setup(trf_host, "trfserver", "magma_trfserver.yml")
+    _setup_vm(test_host, "magma_trfserver", "trfserver", "magma_trfserver.yml", destroy_vm, provision_vm)
+    execute(_start_trfserver)
     execute(_start_trfserver)
 
     # Run the tests: use the provided test machine if given, else default to
     # the vagrant machine
-    if not test_host:
-        test_host = vagrant_setup(
-            'magma_test', destroy_vm, force_provision=provision_vm,
-        )
-    else:
-        ansible_setup(test_host, "test", "magma_test.yml")
-
+    _setup_vm(trf_host, "magma_test", "test", "magma_test.yml", destroy_vm, provision_vm)
     execute(_make_integ_tests)
     execute(_run_integ_tests, gateway_ip)
 
@@ -495,7 +495,7 @@ def integ_test_deb_installation(
 
     gateway_host: The ssh address string of the machine to run the gateway
         services on. Formatted as "host:port". If not specified, defaults to
-        the `magma` vagrant box.
+        the `magma_deb` vagrant box.
 
     test_host: The ssh address string of the machine to run the tests on
         on. Formatted as "host:port". If not specified, defaults to the
@@ -511,36 +511,17 @@ def integ_test_deb_installation(
 
     # Setup the gateway: use the provided gateway if given, else default to the
     # vagrant machine
-    gateway_ip = '192.168.60.142'
-
-    if not gateway_host:
-        gateway_host = vagrant_setup(
-            'magma_deb', destroy_vm, force_provision=provision_vm,
-        )
-    else:
-        ansible_setup(gateway_host, "deb", "magma_deb.yml")
-        gateway_ip = gateway_host.split('@')[1].split(':')[0]
+    _, gateway_ip = _setup_gateway(gateway_host, "magma_deb", "deb", "magma_deb.yml", destroy_vm, provision_vm)
     execute(_restart_gateway)
 
     # Setup the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
-    if not trf_host:
-        trf_host = vagrant_setup(
-            'magma_trfserver', destroy_vm, force_provision=provision_vm,
-        )
-    else:
-        ansible_setup(trf_host, "trfserver", "magma_trfserver.yml")
+    _setup_vm(test_host, "magma_trfserver", "trfserver", "magma_trfserver.yml", destroy_vm, provision_vm)
     execute(_start_trfserver)
 
     # Run the tests: use the provided test machine if given, else default to
     # the vagrant machine
-    if not test_host:
-        test_host = vagrant_setup(
-            'magma_test', destroy_vm, force_provision=provision_vm,
-        )
-    else:
-        ansible_setup(test_host, "test", "magma_test.yml")
-
+    _setup_vm(trf_host, "magma_test", "test", "magma_test.yml", destroy_vm, provision_vm)
     execute(_make_integ_tests)
     execute(_run_integ_tests, gateway_ip)
 


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary
This PR adds a new github action workflow to the ci. The workflow executes lte integ tests against an agw created by debian packages. It is triggered on master after the build-all step is done. 

## Test Plan
- [ ] LTE integ tests on local machine
- [ ] Workflow in CI run through 

## Additional Information

This change is not backwards-breaking
