### PR TITLE
ci: upgrade actions/github-script 

### DIFF
--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -43,7 +43,7 @@ jobs:
   AutoLabelPR:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+      - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
             let newCompLbls = new Set(); // Set of new label strings
@@ -117,7 +117,7 @@ jobs:
             } // end of for loop
 
 
-            const curLblObjs = await github.issues.listLabelsOnIssue({
+            const curLblObjs = await github.rest.issues.listLabelsOnIssue({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -131,7 +131,7 @@ jobs:
                   newCompLbls.delete(l['name']);
                 }
                 else  {
-                  github.issues.removeLabel({
+                  github.rest.issues.removeLabel({
                     issue_number: context.issue.number,
                     owner: context.repo.owner,
                     repo: context.repo.repo,
@@ -146,7 +146,7 @@ jobs:
             }
             else  {
               let uniqLbls = Array.from(newCompLbls);
-              github.issues.addLabels({
+              github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -32,10 +32,10 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -43,7 +43,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -54,7 +54,7 @@ jobs:
       - run: unzip pr.zip
       - name: Check if the workflow is skipped
         id: skip_check
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
             var fs = require('fs');
@@ -80,10 +80,10 @@ jobs:
     steps:
       # Retrieve PR number from triggering workflow artifacts
       - name: 'Download artifact'
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -91,7 +91,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -133,7 +133,7 @@ jobs:
           - [Instructions on formatting your Markdown changes](https://github.com/magma/magma/wiki/Contributing-Documentation#precommit)
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg
       - name: Comment on PR
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
             var fs = require('fs');
@@ -151,7 +151,7 @@ jobs:
             var newMsg = '';
             //var shortCommitId = process.env.COMMIT_ID.substr(0,8);;
 
-            const commentsList = await github.issues.listComments({
+            const commentsList = await github.rest.issues.listComments({
                                         owner: context.repo.owner,
                                         repo: context.repo.repo,
                                         issue_number: issue_number,
@@ -169,7 +169,7 @@ jobs:
                   }
                   newMsg = msg + "\n\n" + updMsg;
                   console.log("UPDATING comment=" + newMsg);
-                  github.issues.updateComment({
+                  github.rest.issues.updateComment({
                                 owner: context.repo.owner,
                                 repo: context.repo.repo,
                                 comment_id: commentId,
@@ -181,7 +181,7 @@ jobs:
 
             if( (commentId == 0) && (process.env.WORKFLOW_STATUS == 'failure') ) {
               console.log("CREATING comment=" + msg);
-              github.issues.createComment({
+              github.rest.issues.createComment({
                             issue_number: issue_number,
                             owner: context.repo.owner,
                             repo: context.repo.repo,

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Check if PR is a Reverted PR
         id: reverted_pr_check
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
             if( process.env.PR_TITLE.startsWith('Revert') ) {

--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       # Retrieve Generated artifacts and delete them to keep cache usage low
       - name: Download builds
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -46,7 +46,7 @@ jobs:
                 console.log(String(matchMetadataArtifact));
                 continue;
               }
-              var download = await github.actions.downloadArtifact({
+              var download = await github.rest.actions.downloadArtifact({
                             owner: context.repo.owner,
                             repo: context.repo.repo,
                             artifact_id: matchMetadataArtifact.id,
@@ -54,7 +54,7 @@ jobs:
                          });
               fs.writeFileSync('${{github.workspace}}/artifact' + i + '.zip', Buffer.from(download.data));
               console.log('Downloaded ' + matchMetadataArtifact.name + ' and placed it there ${{github.workspace}}/artifact' + i + '.zip');
-              github.actions.deleteArtifact({
+              github.rest.actions.deleteArtifact({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 artifact_id: matchMetadataArtifact.id
@@ -71,7 +71,7 @@ jobs:
           done
       - name: Save metadata
         id: save_metadata
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
             var fs = require('fs');

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -21,7 +21,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+      - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -47,7 +47,7 @@ jobs:
             - [CI Checks](https://github.com/magma/magma/wiki/Contributing-Code#continuous-integration-ci--continuous-deployment-cd) for points of contact for failing or flaky CI checks
             - [GitHub-to-Slack mappings for Magma maintainers](https://github.com/magma/magma/wiki/Overview-of-the-Community-Structure-and-Governance) for guidance on how to contact maintainers on Slack`
 
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Check if PR is a Reverted PR
         id: reverted_pr_check
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
             if( process.env.PR_TITLE.startsWith('Revert') ) {

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -29,10 +29,10 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -40,7 +40,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -51,7 +51,7 @@ jobs:
       - run: unzip pr.zip
       - name: Check if the workflow is skipped
         id: skip_check
-        uses: actions/github-script@47f7cf65b5ced0830a325f705cad64f2f58dddf7 # pin@v3.1.0
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:
           script: |
             var fs = require('fs');


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

Several github actions are deprecated because they use Node 12.
This PR upgrades the github action `actions/github-script`.


## Test Plan

## Additional Information

- [ ] This change is backwards-breaking
